### PR TITLE
Add testing information section to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -22,6 +22,7 @@ A clear and concise description of what you expected to happen.
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
+test
 
 **Desktop (please complete the following information):**
  - OS: [e.g. iOS]


### PR DESCRIPTION
Added a placeholder for testing information in the bug report template.